### PR TITLE
Handle 502 Server Error from OneSignal Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ If you want to send a notification only to specific targets (a particular user's
 pass a `OneSignal::IncludedTargets` to the notification object.
 See [the official documentation](https://documentation.onesignal.com/reference#section-send-to-specific-devices) for a list of available params.
 ```ruby
-included_targets = OneSignal::IncludedTargets.new(include_player_ids: 'test-id-12345')
+included_targets = OneSignal::IncludedTargets.new(include_player_ids: ['test-id-12345'])
 OneSignal::Notification.new(included_targets: included_targets)
 ```
 

--- a/lib/onesignal/client.rb
+++ b/lib/onesignal/client.rb
@@ -46,9 +46,9 @@ module OneSignal
     end
 
     def csv_export extra_fields: nil, last_active_since: nil, segment_name: nil
-      post "players/csv_export?app_id=#{@app_id}", 
-        extra_fields: extra_fields, 
-        last_active_since: last_active_since&.to_i&.to_s, 
+      post "players/csv_export?app_id=#{@app_id}",
+        extra_fields: extra_fields,
+        last_active_since: last_active_since&.to_i&.to_s,
         segment_name: segment_name
     end
 
@@ -91,7 +91,12 @@ module OneSignal
     end
 
     def handle_errors res
-      errors = JSON.parse(res.body).fetch 'errors', []
+      json = begin
+               JSON.parse(res.body)
+             rescue JSON::ParserError, TypeError
+               {}
+             end
+      errors = json.fetch('errors', [])
       raise ApiError, (errors.first || "Error code #{res.status}") if res.status > 399 || errors.any?
 
       res

--- a/spec/onesignal/client_spec.rb
+++ b/spec/onesignal/client_spec.rb
@@ -18,6 +18,13 @@ describe Client do
       }.not_to raise_error
     end
 
+    it 'raises an error if the response does not have body' do
+      res = double :res, body: nil, status: 204
+      expect {
+        expect(subject.send :handle_errors, res)
+      }.not_to raise_error
+    end
+
     it 'raises an error if the response code is greater than 399' do
       res = double :res, body: '{ "errors": ["Internal Server Error"] }', status: 500
       expect {
@@ -30,6 +37,17 @@ describe Client do
       expect {
         subject.send :handle_errors, res
       }.to raise_error Client::ApiError, 'Error code 401'
+    end
+
+    it 'raises an error if the response is a html' do
+      body = '<html><head><meta http-equiv="content-type" content="text/html;charset=utf-8">'\
+        '<title>502 Server Error</title></head><body text=#000000 bgcolor=#ffffff><h1>Error: Server Error</h1>'\
+        '<h2>The server encountered a temporary error and could not complete your request.'\
+        '<p>Please try again in 30 seconds.</h2><h2></h2></body></html>'
+      res = double :res, body: body, status: 502
+      expect {
+        subject.send :handle_errors, res
+      }.to raise_error Client::ApiError, 'Error code 502'
     end
 
     it 'raises an error if the body contains errors' do


### PR DESCRIPTION
Hello,

while we are working with OneSignal Client we faced with issue when OneSignal Server returns 502 error with an html response, which breaks JSON.parse code.
so I fixed it, and now OneSignal::Client handle_errors without crashes.

Please merge it or tell me what should I do to get this pull request merged.